### PR TITLE
Various UI changes for nicer look

### DIFF
--- a/src/chrome/content/overlay.js
+++ b/src/chrome/content/overlay.js
@@ -175,7 +175,7 @@ ThumbnailZoomPlusChrome.Overlay = {
   // and the popup when the border is displayed.  This must equal the
   // #thumbnailzoomplus-panel "padding" value in overlay.css.
   // Debugging tip: set large (30) when debugging popup positioning.
-  _borderWidth : 5, // border itself adds 5 pixels on each edge.
+  _borderWidth : 0, // border itself adds 5 pixels on each edge.
   
   // _widthAddon is additional image width due to border if enabled:
   // 0 or _borderWidth*2.

--- a/src/chrome/skin/all/overlay.css
+++ b/src/chrome/skin/all/overlay.css
@@ -54,8 +54,9 @@ toolbar[mode="icons"] #thumbnailzoomplus-toolbar-button {
      on page flags.borderColor */
   background-color: white;
   margin: 0px;
-  /* the padding value here must match _borderWidth in overlay.js. */
-  padding: 5px;
+  /* the padding value here must match _borderWidth in overlay.js.
+      Don't add padding on bottom as the caption text will act as bottom border. */
+  padding: 0px;
   border: none !important;
 }
 #thumbnailzoomplus-border-box[panelnoborder=true] {
@@ -96,7 +97,7 @@ toolbar[mode="icons"] #thumbnailzoomplus-toolbar-button {
 #thumbnailzoomplus-panel-vbox {
   /* Set the caption's background.  We do it on the vbox rather
      than the caption label so it'll span the entire width of the pop-up. */
-  background-color: #AAA !important;
+  background-color: #FFF !important;
   /* debug: background-color: blue !important; */
 }
 #thumbnailzoomplus-panel-info {
@@ -110,6 +111,9 @@ toolbar[mode="icons"] #thumbnailzoomplus-toolbar-button {
   border-radius: 5px;
   font-weight:bold;
   font-size:9px !important;
+
+  /* Space the info box equally from the sides of the image*/
+  margin-bottom: 6px;
 }
 
 #thumbnailzoomplus-panel-caption {


### PR DESCRIPTION
**Changes**
- Removed border from overlay. (See notes below)
- White caption background
- Info overlay (scaling %) now spaced equally from image on right and bottom sides

![screen shot 2013-10-27 at 4 18 24 pm](https://f.cloud.github.com/assets/1301625/1416281/00297228-3f45-11e3-9f49-33370f9082b6.png)

**Rational for removal of border:**
- There was no apparent documentation to the end user what the blue border meant. Only after digging in the code did I learn that it indicated the link was to a page and not an image.
- Looking at the link location at the bottom of the window in the status bar would indicate to the user what type of link it is. Having a border colour duplicates this information.
- Subjectively, I thought the overlay looked better without a border.

If you're still keen on displaying to the user what kind of documents the images link to, let's discuss a better way of doing it. Preferably a method that would be obvious to users right from the start. Otherwise, I'll clean up the code to remove all traces of the border code.

Tell me what you think about these changes. 
