### PR TITLE
Minor bug fixes: few var declarations prevented TZP to be loaded in Firefox 3.0

### DIFF
--- a/src/resources/pages.js
+++ b/src/resources/pages.js
@@ -1667,7 +1667,7 @@ ThumbnailZoomPlus.Pages.OthersIndirect = {
     
     re = /flv_player.*?<img src=\"([^\"]+)"/;
     logger.debug("_getImgFromHtmlText: trying " + re);
-    let match = re.exec(aHTMLString);
+    match = re.exec(aHTMLString);
     if (match) {
       flags.borderColor = "#CC181E"; // youtube red
       return match[1];
@@ -1675,7 +1675,7 @@ ThumbnailZoomPlus.Pages.OthersIndirect = {
     
     re = /flash-player-embed.*?url_bigthumb=([^&]*)/;
     logger.debug("_getImgFromHtmlText: trying " + re);
-    let match = re.exec(aHTMLString);
+    match = re.exec(aHTMLString);
     if (match) {
       flags.borderColor = "#CC181E"; // youtube red
       return match[1];
@@ -1683,7 +1683,7 @@ ThumbnailZoomPlus.Pages.OthersIndirect = {
     
     re = /<img src=\"([^\"]*image.enue.com\/loc[^"]*)/;
     logger.debug("_getImgFromHtmlText: trying " + re);
-    let match = re.exec(aHTMLString);
+    match = re.exec(aHTMLString);
     if (match) {
       return match[1];
     }
@@ -2349,7 +2349,7 @@ ThumbnailZoomPlus.Pages.Thumbnail = {
     aImageSrc = aImageSrc.replace(regEx, "$1/full/$3");
     
     // For xh*ster.com, change 000/014/111/004_160.jpg to 000/014/111/004_1000.jpg
-    let regEx = new RegExp("(xh[a-z0-9]*ster.com.*/[0-9]+/[0-9]+/[0-9]+/[0-9]+)_[0-9]{1,3}(\.[a-z]+)");
+    regEx = new RegExp("(xh[a-z0-9]*ster.com.*/[0-9]+/[0-9]+/[0-9]+/[0-9]+)_[0-9]{1,3}(\.[a-z]+)");
     before = aImageSrc;
     aImageSrc = aImageSrc.replace(regEx, "$1_1000$2");
     aImageSrc = aImageSrc.replace(/\/livesnap100\//, "/livesnap320/");


### PR DESCRIPTION
This patch will make TZP loadable in Firefox 3.0 (Windows). I haven't went through all the test cases, but some worked and some did not.

Maybe I would just bump the minimal version to 3.6.
