### PR TITLE
Adds gyazo.com support, adds direct .mp4 link support and fixes >11 imgur album not working on gif albums

### DIFF
--- a/src/resources/pages.js
+++ b/src/resources/pages.js
@@ -1813,12 +1813,20 @@ ThumbnailZoomPlus.Pages.OthersIndirect = {
         return this._allMatchesOf(re, match, aHTMLString, "$1");
       }
     }
-
-    // blip.tv, imgur.com/a/, gyazo.com... (imgur may need .jpg added):
+    
+    // gyazo.com
+    // <meta content="http://i.gyazo.com/5a72871c5d808492e41c732a71dca8e8.png" name="twitter:image" />
+    re = /<meta +content=\"([^\"]+)"\s+name="twitter:image"/;
+    logger.debug("_getImgFromHtmlText: trying " + re);
+    match = re.exec(aHTMLString);
+    if (match) {
+        return match[1];
+    }
+    
+    // blip.tv, imgur.com/a/... (imgur may need .jpg added):
     //	<meta name="twitter:image"
     //     value="http://3.i.blip.tv/g?src=Rat2008-Micros02464-972.jpg&w=120&h=120&fmt=png&bc=FFFFFF&ac=0"/>
-    // gyazo.com uses "content" for the URL rather than value
-    re = /<meta +name="twitter:image"\s+(?:value|content)=\"([^\"]+)"/;
+    re = /<meta +name="twitter:image"\s+value=\"([^\"]+)"/;
     logger.debug("_getImgFromHtmlText: trying " + re);
     match = re.exec(aHTMLString);
     if (match) {


### PR DESCRIPTION
The direct linking mp4 support goes hand-in-hand with the gyazo support, since gyazo supplies MP4s for all their gif links, so all gyazo gif links are replaces with their respective mp4 links.
[Direct linking mp4 example](http://www.nasa.gov/mp4/645169main_v1218a_H264m.mp4)
[Gyazo non-gif link](http://gyazo.com/5a72871c5d808492e41c732a71dca8e8)
[Gyazo gif link](http://gyazo.com/3a087c19400cc960039a734ff66a488d) (should load mp4 version)

The regex for the >11 imgur album fix was missing the "gif" extension, so albums with gif files were falling back to the old method. [Example, shows 11 images pre-commit, 17 post-commit](http://imgur.com/a/zhRXo)
