### PR TITLE
RMB handling is broken on windows

### DIFF
--- a/src/chrome/content/overlay.js
+++ b/src/chrome/content/overlay.js
@@ -4408,13 +4408,14 @@ ThumbnailZoomPlusChrome.Overlay = {
         return;
       }
 
-      var target = aEvent.explicitOriginalTarget || aEvent.target;
-      if (target.localName.toLowerCase() == "textarea") {
-        // Don't prevent context menu in textareas since that would prevent spell check suggestions (#172).
-        this._logger.debug("_handleContextMenu: skipping due to target element target=" + target.localName.toLowerCase());
-        return;
-      }
-      
+      if (this._postponeContextMenuEvent) {
+        var target = aEvent.explicitOriginalTarget || aEvent.target;
+        if (target.localName.toLowerCase() == "textarea") {
+          // Don't prevent context menu in textareas since that would prevent spell check suggestions (#172).
+          this._logger.debug("_handleContextMenu: skipping due to target element target=" + target.localName.toLowerCase());
+          return;
+        }
+
         /*
          * All contextmenu events originated from RMB should be postponed until
          * the RMB is released. In the meantime we decide if we want to prevent

--- a/src/chrome/content/overlay.js
+++ b/src/chrome/content/overlay.js
@@ -4482,10 +4482,6 @@ ThumbnailZoomPlusChrome.Overlay = {
     this._logger.debug("_handleMouseUp: disabling _postponeContextMenuEvent.");
     this._postponeContextMenuEvent = false;
 
-    // a side-effect of redispatching the event seems to be preventing
-    // spell-check suggestions.  The problem happens even if we create the
-    // event differently or dispatch on a different target; see #172.
-    if (true) {
     var freshMouseEvent = document.createEvent("MouseEvents");
     freshMouseEvent.initMouseEvent(
       aMouseEvent.type,
@@ -4504,31 +4500,6 @@ ThumbnailZoomPlusChrome.Overlay = {
       aMouseEvent.button,
       aMouseEvent.relatedTarget
     );
-    } else {
-      var freshMouseEvent = new MouseEvent(aMouseEvent.type, {
-      'bubbles': aMouseEvent.bubbles,
-      'cancelable': aMouseEvent.cancelable,
-      'view': aMouseEvent.view,
-      'detail': aMouseEvent.detail,
-      'screenX': aMouseEvent.screenX,
-      'screenY': aMouseEvent.screenY,
-      'clientX': aMouseEvent.clientX,
-      'clientY': aMouseEvent.clientY,
-      'ctrlKey': aMouseEvent.ctrlKey,
-      'altKey': aMouseEvent.altKey,
-      'shiftKey': aMouseEvent.shiftKey,
-      'metaKey': aMouseEvent.metaKey,
-      'button': aMouseEvent.button,
-      'relatedTarget': aMouseEvent.relatedTarget,
-      'target': aMouseEvent.target,
-      'originalTarget': aMouseEvent.originalTarget,
-      'explicitOriginalTarget': aMouseEvent.explicitOriginalTarget
-  });
-  }
-  
-    //var target = aMouseEvent.originalTarget;
-    //var target = aMouseEvent.target;
-    //var target = aMouseEvent.explicitOriginalTarget;
     var target = aMouseEvent.explicitOriginalTarget;
     this._logger.debug("_redispatchMouseEvent: redispatching event " + aMouseEvent.type + " on " + target);
     target.dispatchEvent(freshMouseEvent);


### PR DESCRIPTION
Hi,
few recent changes broke handling rmb in windows, maybe linux too. This pull request introduce:
- some clean up after be6c29e8e2624e81a8b702638989e0be037192d9 (no problem here)
- rollback of bb4ea72c827509cd4c8a35777c01fa2444d7fff4 - this is suppposed to fix issue described in [your comment][1] (which I wasn't able to reproduce on windows). Maybe it does fix it for Mac, but it breaks windows and probably linux. We need to fix it other way. The rollback preserves fix for #172, but I needed to shift it few lines.

[1]: https://github.com/dadler/thumbnail-zoom/pull/144#issuecomment-57897789