### PR TITLE
Allows hosting pages to be usable under the "file:" protocol

### DIFF
--- a/src/resources/filterService.js
+++ b/src/resources/filterService.js
@@ -172,7 +172,7 @@ ThumbnailZoomPlus.FilterService = {
     if ("http:" == protocol || "https:" == protocol) {
       return true;
     }
-    if (!strict && ("chrome:" == protocol || "data:" == protocol)) {
+    if (!strict && ("chrome:" == protocol || "data:" == protocol || "file:" == protocol)) {
       // allow the hosting page to be in chrome://, e.g. for
       // extensions like PrevNextArrows and showmemore.
       return true;


### PR DESCRIPTION
Fixes #209
This only applies to pages loaded as non-strict (image nodes are loaded as strict at https://github.com/dadler/thumbnail-zoom/blob/master/src/chrome/content/overlay.js#L1732)

You can test this by running TestCase.html locally, everything should work except the gradient image test and the existing host test, since both fall under the "file://" protocol, and of course the "Security" section should work the same as before.
